### PR TITLE
Look at download URL AFTER redirects

### DIFF
--- a/background.js
+++ b/background.js
@@ -8,13 +8,13 @@ const doWork = (downloadItem) => {
 
     //console.log(downloadItem);
     const regexPattern = /https?:\/\/([^/]+\/)+[^/]+\.application(\?.*)?/;
-    if(downloadItem.state === "in_progress" && downloadItem.mime === "application/x-ms-application" && regexPattern.test(downloadItem.url)){
+    if(downloadItem.state === "in_progress" && downloadItem.mime === "application/x-ms-application" && regexPattern.test(downloadItem.finalUrl)){
         try{
             canceledDownloadIds.push(downloadItem.id);
             chrome.downloads.cancel(downloadItem.id);
         }
         catch{}
-        chrome.runtime.sendNativeMessage('breez.clickonce.clickoncehelper', { url: downloadItem.url })
+        chrome.runtime.sendNativeMessage('breez.clickonce.clickoncehelper', { url: downloadItem.finalUrl })
         .catch(err => {
             //console.log(err);
             chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {


### PR DESCRIPTION
Ran into some issues where application uses redirects to dynamically append parameters (eg: temp auth tokens). By using finalUrl, we can ensure that we would utilize the end-result AFTER directs.

Ref: https://developer.chrome.com/docs/extensions/reference/api/downloads#property-DownloadQuery-finalUrl